### PR TITLE
fix: preserve newline runs, incl. in template literals

### DIFF
--- a/test-files/expected.js
+++ b/test-files/expected.js
@@ -11,3 +11,13 @@ console.log("Hello from JavaScript 2");
 export function bar(foo) {
   return new Date();
 }
+
+const templateLiteral = `one
+
+two
+`;
+
+const stringLiteral = "one\
+\
+two\
+";

--- a/test-files/expected.ts
+++ b/test-files/expected.ts
@@ -21,3 +21,13 @@ console.log("Hello from TypeScript 2");
 export function bar(foo: Foo): Date {
   return new Date();
 }
+
+const templateLiteral: string = `one
+
+two
+`;
+
+const stringLiteral: string = "one\
+\
+two\
+";

--- a/test-files/input.ts
+++ b/test-files/input.ts
@@ -30,3 +30,13 @@ console.log("Hello from TypeScript 2");
 export function bar(foo: Foo): Date {
   return new Date();
 }
+
+const templateLiteral: string = `one
+
+two
+`;
+
+const stringLiteral: string = "one\
+\
+two\
+";


### PR DESCRIPTION
detype currently inserts extra newlines into template literals.

Currently, this:

```ts
const foo = `first

second`;
```

becomes this:

```ts
const foo = `first



second`;
```

which means `detype` can change a program's semantics.

To fix this, track the number of empty lines that were replaced, e.g.

```ts
/* @detype: empty-line=5 */
```

so we can reinsert them, while still removing newline runs introduced by
type removal.

As a side effect, this will preserve all newline runs in the input,
including those not in template literals. We could limit this to
template literals only by adding a TemplateLiteral case to the Babel
transform.
