### PR TITLE
feat: support transform defineProps's and defineEmits's types to parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@babel/core": "^7.21.4",
 		"@babel/preset-typescript": "^7.21.4",
 		"@vue/compiler-dom": "^3.2.47",
+		"@vue/compiler-sfc": "^3.2.47",
 		"@vuedx/compiler-sfc": "0.7.1",
 		"@vuedx/template-ast-types": "0.7.1",
 		"fast-glob": "^3.2.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ dependencies:
   '@vue/compiler-dom':
     specifier: ^3.2.47
     version: 3.2.47
+  '@vue/compiler-sfc':
+    specifier: ^3.2.47
+    version: 3.3.4
   '@vuedx/compiler-sfc':
     specifier: 0.7.1
     version: 0.7.1
@@ -714,7 +717,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
@@ -996,6 +998,15 @@ packages:
       source-map: 0.6.1
     dev: false
 
+  /@vue/compiler-core@3.3.4:
+    resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
+    dependencies:
+      '@babel/parser': 7.21.4
+      '@vue/shared': 3.3.4
+      estree-walker: 2.0.2
+      source-map-js: 1.0.2
+    dev: false
+
   /@vue/compiler-dom@3.2.47:
     resolution: {integrity: sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==}
     dependencies:
@@ -1003,8 +1014,51 @@ packages:
       '@vue/shared': 3.2.47
     dev: false
 
+  /@vue/compiler-dom@3.3.4:
+    resolution: {integrity: sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==}
+    dependencies:
+      '@vue/compiler-core': 3.3.4
+      '@vue/shared': 3.3.4
+    dev: false
+
+  /@vue/compiler-sfc@3.3.4:
+    resolution: {integrity: sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==}
+    dependencies:
+      '@babel/parser': 7.21.4
+      '@vue/compiler-core': 3.3.4
+      '@vue/compiler-dom': 3.3.4
+      '@vue/compiler-ssr': 3.3.4
+      '@vue/reactivity-transform': 3.3.4
+      '@vue/shared': 3.3.4
+      estree-walker: 2.0.2
+      magic-string: 0.30.3
+      postcss: 8.4.21
+      source-map-js: 1.0.2
+    dev: false
+
+  /@vue/compiler-ssr@3.3.4:
+    resolution: {integrity: sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==}
+    dependencies:
+      '@vue/compiler-dom': 3.3.4
+      '@vue/shared': 3.3.4
+    dev: false
+
+  /@vue/reactivity-transform@3.3.4:
+    resolution: {integrity: sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==}
+    dependencies:
+      '@babel/parser': 7.21.4
+      '@vue/compiler-core': 3.3.4
+      '@vue/shared': 3.3.4
+      estree-walker: 2.0.2
+      magic-string: 0.30.3
+    dev: false
+
   /@vue/shared@3.2.47:
     resolution: {integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==}
+    dev: false
+
+  /@vue/shared@3.3.4:
+    resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
     dev: false
 
   /@vuedx/compiler-sfc@0.7.1:
@@ -2543,7 +2597,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -2620,7 +2673,6 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
@@ -2919,7 +2971,6 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3143,7 +3194,6 @@ packages:
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -93,7 +93,7 @@ export async function transform(
 
 		const isContainsDefinePropsType =
 			script2?.content.match(/defineProps\s*</m);
-		const isContainsDefineEmitType = script2?.content.match(/defineProps\s*</m);
+		const isContainsDefineEmitType = script2?.content.match(/defineEmits\s*</m);
 
 		if (isContainsDefinePropsType || isContainsDefineEmitType) {
 			const { content } = compileScript(parsedVue.descriptor as any, {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -9,6 +9,7 @@ import {
 	SFCTemplateBlock as VueSfcTemplateBlock,
 	SFCScriptBlock as VueSfcScriptBlock,
 } from "@vuedx/compiler-sfc";
+import { compileScript } from "@vue/compiler-sfc";
 import {
 	traverse as traverseVueAst,
 	isSimpleExpressionNode as isVueSimpleExpressionNode,
@@ -23,6 +24,25 @@ import babelTs from "@babel/preset-typescript";
 // @ts-expect-error: No typinggs
 import { shim } from "string.prototype.replaceall";
 shim();
+
+function getDefinePropsObject(content: string) {
+	const matched = /\sprops:\s*\{/m.exec(content);
+	if (matched) {
+		const startContentIndex = matched.index + matched[0].length - 1;
+		let leftBracketCount = 1;
+		let endContentIndex = startContentIndex + 1;
+		while (leftBracketCount) {
+			if (content.charAt(endContentIndex) === "{") {
+				leftBracketCount++;
+			} else if (content.charAt(endContentIndex) === "}") {
+				leftBracketCount--;
+			}
+			endContentIndex++;
+		}
+		return content.substring(startContentIndex, endContentIndex);
+	}
+	return "";
+}
 
 type VueElementNode = VueSfcTemplateBlock["ast"];
 
@@ -53,6 +73,8 @@ export async function transform(
 
 	const originalCode = code;
 	const originalFileName = fileName;
+	let propsContent = "";
+	let emitsContent = "";
 
 	code = code.replaceAll("\r\n", "\n");
 
@@ -68,6 +90,23 @@ export async function transform(
 		}
 
 		let { script: script1, scriptSetup: script2 } = parsedVue.descriptor;
+
+		const isContainsDefinePropsType =
+			script2?.content.match(/defineProps\s*</m);
+		const isContainsDefineEmitType = script2?.content.match(/defineProps\s*</m);
+
+		if (isContainsDefinePropsType || isContainsDefineEmitType) {
+			const { content } = compileScript(parsedVue.descriptor as any, {
+				id: "xxxxxxx",
+			});
+
+			if (isContainsDefinePropsType) {
+				propsContent = getDefinePropsObject(content);
+			}
+			if (isContainsDefineEmitType) {
+				emitsContent = content.match(/\semits:\s(\[.*\]?)/m)?.[1] || "";
+			}
+		}
 
 		// Process the second script first to simplify code location handling
 		if (
@@ -95,6 +134,13 @@ export async function transform(
 		);
 	} else {
 		code = await removeTypes(code, fileName, removeTypeOptions);
+	}
+
+	if (propsContent) {
+		code = code.replace("defineProps(", (str) => `${str}${propsContent}`);
+	}
+	if (emitsContent) {
+		code = code.replace("defineEmits(", (str) => `${str}${emitsContent}`);
 	}
 
 	code = format(code, {

--- a/test-files/expected/input.vue
+++ b/test-files/expected/input.vue
@@ -22,15 +22,21 @@ console.log("This is the non-setup script");
 import MyComponent from "MyComponent.vue";
 import { someConst, otherConst } from "some-module";
 
+const props = defineProps({
+  prop: { type: String, required: true },
+  array: { type: Array, required: true },
+});
+
+const emit = defineEmits(["change", "update"]);
+
 let x;
 
 // This comment should be kept
 
 // This comment should also be kept
-export function bar(foo) {
-  return new Date();
-}
-
+defineExpose({
+  foo: "bar",
+});
 const otherProps = {};
 const arr1 = [];
 const arr2 = [];

--- a/test-files/input.vue
+++ b/test-files/input.vue
@@ -23,6 +23,16 @@ import MyComponent from "MyComponent.vue";
 import { someConst, otherConst } from "some-module";
 import type { ParsedPath } from "path";
 
+const props = defineProps<{
+  prop: string;
+  array: string[];
+}>();
+
+const emit = defineEmits<{
+  (e: "change", id: number): void;
+  (e: "update", value: string): void;
+}>();
+
 let x: string;
 
 // This comment should be kept
@@ -35,10 +45,9 @@ interface Foo {
 }
 
 // This comment should also be kept
-export function bar(foo: Foo): Date {
-  return new Date();
-}
-
+defineExpose({
+  foo: "bar",
+});
 const otherProps = {};
 const arr1: number[] = [];
 const arr2: string[] = [];


### PR DESCRIPTION
Just removing all the types from `vue` will result in missing props and emits. This PR will transform types into parameters 

More about refer to https://github.com/radix-vue/shadcn-vue/issues/62